### PR TITLE
Upgrade from 17.0.2 to 17.0.11

### DIFF
--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/gradle/service
 
 RUN ./gradlew --build-cache bootJar
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre-jammy
 
 EXPOSE 8081
 


### PR DESCRIPTION
The original openjdk isn't supported anymore. Switch to eclipse-temurin image which provides continued support until October 2027.

This will bring in the latest security fixes.