### PR TITLE
Add Bundle section to mapping doc

### DIFF
--- a/doc/ITK_FHIR_mapping.md
+++ b/doc/ITK_FHIR_mapping.md
@@ -323,7 +323,7 @@
 | No mapping |  | .item |
 | No mapping |  | item |
 
-## Questionnaire
+## Questionnaire
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |

--- a/doc/ITK_FHIR_mapping.md
+++ b/doc/ITK_FHIR_mapping.md
@@ -1,3 +1,45 @@
+# Bundle
+
+The 111 Adaptor will convert each ITK Clinical Document Architecture XML document into a [FHIR Bundle] encoded as JSON.
+
+| ITK Mapping Element                      | FHIR Objects 3.0.2                                          | FHIR Mapping Elements 3.0.2 |
+|------------------------------------------|-------------------------------------------------------------|-----------------------------|
+|                                          | UTC timestamp of when the adaptor received the ITK document | Meta.lastUpdated            |
+|                                          | HARDCODED: `"ClinicalDocument VersionNumber"`               | identifier.type.text        |
+| ClinicalDocument / versionNumber[@value] |                                                             | identifier.value            |
+|                                          | HARDCODED: `"message"`                                      | type                        |
+|                                          | List of resources as described below                        | entry                       |
+
+Each bundle will include within its `entry` array:
+
+- 0..1 [Appointment](#appointment)
+- 0..* [CarePlan](#careplan)
+- 1    [Composition](#composition)
+- 1    [Condition](#condition)
+- 1    [Consent](#consent)
+- 1    [Device](#device)
+- 1    [Encounter](#encounter)
+- 0..1 Group
+- 0..* [HealthcareService](#healthcareservice)
+- 1    [List](#list)
+- 0..* [Location](#location)
+- 1    [MessageHeader](#messageheader)
+- 0..* [Observation](#observation)
+- 0..* [Organization](#organization)
+- 1    [Organization (service provider)](#organization-service-provider)
+- 0..* [Participant](#participant)
+- 0..* [Patient](#patient)
+- 0..* [Practitioner](#practitioner)
+- 0..* PractitionerRole author
+- 0..1 [PractitionerRole responsibleParty](#practitionerrole-responsibleparty)
+- 0..1 [ProcedureRequest](#procedurerequest)
+- 0..* [Questionnaire](#questionnaire)
+- 0..* [QuestionnaireResponse](#questionnaireresponse)
+- 1    [ReferralRequest](#referralrequest)
+- 0..1 [RelatedPerson](#relatedperson)
+
+[FHIR Bundle]: https://hl7.org/fhir/stu3/bundle.html
+
 ## Encounter
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |

--- a/doc/ITK_FHIR_mapping.md
+++ b/doc/ITK_FHIR_mapping.md
@@ -230,7 +230,7 @@
 | Title = `<component><structuredBody> <component><section><title>`<br />Text = `<component><structuredBody> <component><section><text>` |  | Event |
 | See ITK column of Care Plan mapping<br />See ITK column of Referral Request mapping<br />See ITK column of Questionnaire Response mapping<br />`<component><structuredBody> <component><section><title>`<br />`<component><structuredBody> <component><section><text>` | Care planReferral RequestQuestionnaire Response | section |
 
-## Referral Request
+## ReferralRequest
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -293,7 +293,7 @@
 | Not populated |  | link |
 | `<patientRole><patient><ethicGroup>`<br />`<patientRole><patient><religiousAffiliation>`<br />`<patientRole><patient><birthplace>` | HARDCODED: "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-EthnicCategory-1"<br />HARDCODED: "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect"<br />HARDCODED: "http://hl7.org/fhir/StructureDefinition/birthPlace" | Extension |
 
-## Questionnaire Response
+## QuestionnaireResponse
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -309,7 +309,7 @@
 | No mapping |  | Source |
 | See ITK column of Questionnaire Response – Item mapping below |  | item |
 
-## Questionnaire Response – Item
+## QuestionnaireResponse – Item
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -373,7 +373,7 @@
 | No mapping |  | .initial |
 | No mapping |  | .item |
 
-## Procedure Request
+## ProcedureRequest
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -681,7 +681,7 @@ Mapped from `<healthCareFacility><location>`
 | See ITK column of practitioner mapping | Practitioner | individual |
 |  |  |  |
 
-## Practitioner Role (ResponsibleParty)
+## PractitionerRole (ResponsibleParty)
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |

--- a/doc/ITK_FHIR_mapping.md
+++ b/doc/ITK_FHIR_mapping.md
@@ -1,4 +1,4 @@
-## Encounter mapping
+## Encounter
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -119,7 +119,7 @@
 | Not populated |  | availabilityExceptions |
 | Not populated |  | Endpoints |
 
-## Consent mapping
+## Consent
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |

--- a/doc/ITK_FHIR_mapping.md
+++ b/doc/ITK_FHIR_mapping.md
@@ -309,7 +309,7 @@
 | No mapping |  | Source |
 | See ITK column of Questionnaire Response – Item mapping below |  | item |
 
-## QuestionnaireResponse – Item
+### QuestionnaireResponse.Item
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |
@@ -350,7 +350,7 @@
 | No mapping | Hardcoded to patient | subjectType |
 | See ITK column of Questionnaire – Item Mapping below |  | item |
 
-## Questionnaire - Item
+### Questionnaire.Item
 
 | ITK Mapping Element | FHIR Objects 3.0.2 | FHIR Mapping Elements 3.0.2 |
 | --- | --- | --- |


### PR DESCRIPTION
Fixup a number of formatting inconsistencies within other mapped resources. See commits for details of each change.

For a couple of resources, "Group" and "PractitionerRole (author)" we don't actually have any mapping docs, so a future improvement would be to document those too.