### PR TITLE
Remove unused lombok configuration within build.gradle

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -42,11 +42,6 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
-
-lombok {
-    config['lombok.log.fieldName'] = 'LOGGER'
-}
-
 sourceSets {
     integrationTest {
         java {


### PR DESCRIPTION
The lombok gradle plugin no longer manages config options

Config is instead stored within [lombok.config file](https://github.com/NHSDigital/integration-adaptor-111/blob/master/service/lombok.config#L4)