### PR TITLE
Remove duplicate NHS Numbers from test suite

### DIFF
--- a/test-suite/client/src/data/ambulance-itk-request.xml
+++ b/test-suite/client/src/data/ambulance-itk-request.xml
@@ -66,7 +66,6 @@
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>

--- a/test-suite/client/src/data/fhir-structure-itk-request.xml
+++ b/test-suite/client/src/data/fhir-structure-itk-request.xml
@@ -57,7 +57,7 @@
                             <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16" extension="COCD_TP145201GB01#PatientRole" />
                             <patientRole classCode="PAT">
                                 <templateId extension="COCD_TP145201GB01#PatientRole" root="2.16.840.1.113883.2.1.3.2.4.18.2" />
-                                <id extension="9990238359" root="2.16.840.1.113883.2.1.3.2.4.18.23" />
+
                                 <id extension="A0C532E4-6C1B-4B8A-A45C-1108D7E036E2" root="2.16.840.1.113883.2.1.3.2.4.18.24" assigningAuthorityName="Y00397:Devon Doctors Group" />
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" />
                                 <addr use="H">

--- a/test-suite/client/src/data/no-nhs-number-itk-request.xml
+++ b/test-suite/client/src/data/no-nhs-number-itk-request.xml
@@ -69,8 +69,6 @@
                                     extension="@@local-patient-identifier@@"
                                     root="2.16.840.1.113883.2.1.3.2.4.18.24"/>
 
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
-
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>
                                     <streetAddressLine>Woodtown</streetAddressLine>

--- a/test-suite/client/src/data/primary-care-itk-two-locations.xml
+++ b/test-suite/client/src/data/primary-care-itk-two-locations.xml
@@ -68,7 +68,6 @@
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>

--- a/test-suite/client/src/data/primary-emergency-itk-request.xml
+++ b/test-suite/client/src/data/primary-emergency-itk-request.xml
@@ -66,7 +66,6 @@
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>

--- a/test-suite/client/src/data/primary-to-a&e-request.xml
+++ b/test-suite/client/src/data/primary-to-a&e-request.xml
@@ -66,7 +66,6 @@
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>

--- a/test-suite/client/src/data/safeguarding-request.xml
+++ b/test-suite/client/src/data/safeguarding-request.xml
@@ -66,7 +66,6 @@
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
-                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
                                 <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>


### PR DESCRIPTION
A hardcoded NHS number was present in multiple test-suite XML files, resulting in two NHS numbers being returned, one of them hardcoded to a set value.  This was not the dedesired functionality and only one should be returned