### PR TITLE
Upgrade to Spring Framework 6.1

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.18'
+    id 'org.springframework.boot' version '3.3.7'
     id 'io.spring.dependency-management' version '1.1.7'
     id "io.freefair.lombok" version "6.4.2"
     id "checkstyle"
@@ -24,13 +24,13 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.apache.qpid:qpid-jms-client:1.5.0'
+    implementation 'org.apache.qpid:qpid-jms-client:2.6.1'
     implementation 'org.springframework:spring-jms'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:5.7.2'
     implementation 'uk.nhs.connect.iucds:iucds-schema:3.0.RC1.2'
     implementation 'jaxen:jaxen:1.2.0'
     implementation 'org.apache.xmlbeans:xmlbeans:3.1.0'
-    implementation 'com.rabbitmq.jms:rabbitmq-jms:2.3.0'
+    implementation 'com.rabbitmq.jms:rabbitmq-jms:3.4.0'
 
     testImplementation 'org.mockito:mockito-core:4.4.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/service/src/integration-test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerIT.java
+++ b/service/src/integration-test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerIT.java
@@ -24,11 +24,11 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
-import javax.jms.BytesMessage;
-import javax.jms.Destination;
-import javax.jms.IllegalStateException;
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.BytesMessage;
+import jakarta.jms.Destination;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.json.JSONException;

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
@@ -1,7 +1,7 @@
 package uk.nhs.adaptors.oneoneone.cda.report.service;
 
-import javax.jms.Destination;
-import javax.jms.TextMessage;
+import jakarta.jms.Destination;
+import jakarta.jms.TextMessage;
 
 import org.apache.xmlbeans.XmlException;
 import org.hl7.fhir.dstu3.model.Bundle;

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/config/AmqpConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/config/AmqpConfiguration.java
@@ -2,8 +2,8 @@ package uk.nhs.adaptors.oneoneone.config;
 
 import java.util.Objects;
 
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.qpid.jms.JmsConnectionFactory;

--- a/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportServiceTest.java
@@ -5,10 +5,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Session;
-import javax.jms.TextMessage;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 
 import org.apache.xmlbeans.XmlException;
 import org.hl7.fhir.dstu3.model.Bundle;


### PR DESCRIPTION
This version is still in active support, which will improve the security position of the adaptor.

Also upgrade jms packages to ones which support the javax -> jakarta rename.