### PR TITLE
Update class rename as part of Spring Boot 3.2 upgrade

### DIFF
--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -13,4 +13,4 @@ RUN mkdir /app
 
 COPY --from=build /home/gradle/service/build/libs/integration-adaptor-111.jar /app/integration-adaptor-111.jar
 
-ENTRYPOINT ["java", "-cp", "/app/integration-adaptor-111.jar", "-Dloader.main=uk.nhs.adaptors.oneoneone.OneOneOneApplication", "org.springframework.boot.loader.PropertiesLauncher"]
+ENTRYPOINT ["java", "-cp", "/app/integration-adaptor-111.jar", "-Dloader.main=uk.nhs.adaptors.oneoneone.OneOneOneApplication", "org.springframework.boot.loader.launch.PropertiesLauncher"]


### PR DESCRIPTION
This is a follow up to 5cca24c where we upgraded Spring.

This change is documented more here:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support