### PR TITLE
NIAD-3194: Fix spelling issue in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,6 @@ jobs:
               with:
                   message: |
                       Images built and published to ECR using a Build Id of ${{ needs.generate-build-id.outputs.build-id }}
-                  comment_tag: images-built
+                  comment-tag: images-built
                   mode: upsert
 


### PR DESCRIPTION
* Update `comment_tag` to `comment-tag` in GitHub actions build workflow to ensure that current comment is overwritten when multiple builds have occurred for a single PR, such as when the code is updated after the PR has been raised