### PR TITLE
NAID-3331: NHS best practices for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-
 name: 111 Adaptor Build Workflow
 on:
     pull_request:
@@ -13,12 +12,14 @@ jobs:
     checkstyle:
         name: Checkstyle
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Setup Java 21 LTS
-              uses: actions/setup-java@v4
+              uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
               with:
                   java-version: 21
                   distribution: 'temurin'
@@ -35,7 +36,7 @@ jobs:
                   cp -r ./service/build/reports ./artifacts
 
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
               if: always()
               with:
                   name: 'Checkstyle Reports'
@@ -48,12 +49,14 @@ jobs:
     spotbugs:
         name: Spotbugs
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Setup Java 21 LTS
-              uses: actions/setup-java@v4
+              uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
               with:
                   java-version: 21
                   distribution: 'temurin'
@@ -70,7 +73,7 @@ jobs:
                   cp -r ./service/build/reports ./artifacts
 
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
               if: always()
               with:
                   name: 'Spotbugs Reports'
@@ -84,13 +87,15 @@ jobs:
         name: Unit Tests
         runs-on: ubuntu-latest
         needs: [ checkstyle, spotbugs ]
+        permissions:
+            contents: read
         steps:
             -   name: Checkout Repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
                 with:
                     fetch-depth: 0
             -   name: Setup Java 21 LTS
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
                 with:
                     java-version: 21
                     distribution: 'temurin'
@@ -106,7 +111,7 @@ jobs:
                     cp -r ./service/build/reports ./artifacts
 
             -   name: Upload Artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
                 if: always()
                 with:
                     name: 'Unit Test Reports'
@@ -120,12 +125,14 @@ jobs:
         name: Integration Tests
         runs-on: ubuntu-latest
         needs: [ checkstyle, spotbugs ]
+        permissions:
+            contents: read
         steps:
             -   name: Checkout Repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             -   name: Setup Java 21 LTS
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
                 with:
                     java-version: 21
                     distribution: 'temurin'
@@ -160,7 +167,7 @@ jobs:
                     cp -r ./scripts/logs ./artifacts
 
             -   name: Upload Artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
                 if: always()
                 with:
                     name: 'Integration Test Reports & Docker Logs'
@@ -182,11 +189,13 @@ jobs:
         name: Generate Build ID
         runs-on: ubuntu-latest
         needs: [unit-tests, integration-tests]
+        permissions:
+            contents: read
         outputs:
             build-id: ${{ steps.generate.outputs.buildId }}
         steps:
             -   name: Checkout Repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             -   id: generate
                 working-directory: ./scripts
@@ -223,10 +232,10 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Configure AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
               with:
                   role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}
                   role-session-name: 111_github_action_build_workflow
@@ -261,16 +270,16 @@ jobs:
         name: "Create Build ID Comment"
         needs: [generate-build-id]
         continue-on-error: true
-        permissions: write-all
+        permissions:
+            pull-requests: write
         runs-on: [ ubuntu-latest ]
         steps:
             - name: Check out code
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Comment PR
-              uses: thollander/actions-comment-pull-request@v3
+              uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
               with:
                   message: |
                       Images built and published to ECR using a Build Id of ${{ needs.generate-build-id.outputs.build-id }}
                   comment-tag: images-built
                   mode: upsert
-


### PR DESCRIPTION
* Restrict permissions per job to ensure that only the least required permissions are granted in `build` workflow.
* Use SHAs for GitHub Actions `actions` instead of versions to ensure we have control over exactly which version is being used in `build` workflow.
* Change permissions for `Create Build ID Comment` to only allow `write` on pull requests.