### PR TITLE
Update Docker Project Name

### DIFF
--- a/docker/docker-compose-checks.yml
+++ b/docker/docker-compose-checks.yml
@@ -1,4 +1,6 @@
 version: '3.8'
+name: integration-adaptor-111
+
 services:
   integration-adaptor-111:
     container_name: integration-adaptor-111_tests

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: integration-adaptor-111
+
 services:
   integration-adaptor-111:
     build:


### PR DESCRIPTION
**What**

* Update project name to `integration-adaptor-111` in docker-compose files so that when running locally they are not grouped under default `docker` header.

**Why**

When running the containers locally, they were grouped under the default header of `docker` whilst the other projects are grouped by name.  This ensures consistency and makes it easier to find the resources.