### PR TITLE
NAID-2571: Update `com.github.spotbugs` to `6.1.2`

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id "io.freefair.lombok" version "8.12.2"
     id "checkstyle"
-    id "com.github.spotbugs" version "6.0.27"
+    id "com.github.spotbugs" version "6.1.13"
     id "jacoco"
 }
 


### PR DESCRIPTION
## What

* Update `com.github.spotbugs` to `6.1.13`.

## Why

The update uses version `6.1.13` instead due to a defect reintroduced in release `6.2.0` which causes a conflict with logging providers introduced in other plugs [GitHub Issue](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1312)

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation where required
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](../CHANGELOG.md) with details of my change in the UNRELEASED section if this change affects end users.
