### PR TITLE
Add a default value for `externalConfigurationServiceUrl` in `application.yml`

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -27,7 +27,7 @@ soap:
 itk:
   odsCodes: ${PEM111_ITK_ODS_CODE_LIST:}
   dosIds: ${PEM111_ITK_DOS_ID_LIST:}
-  externalConfigurationServiceUrl: ${PEM111_ITK_EXTERNAL_CONFIGURATION_URL:}
+  externalConfigurationServiceUrl: ${PEM111_ITK_EXTERNAL_CONFIGURATION_URL:http://localhost:8110/configuration/ods-dos}
   fetchIntervalMinutes: ${PEM111_ITK_FETCH_INTERVAL_MIN:5}
 
 version: ${PEM111_VERSION:1.0.3}


### PR DESCRIPTION
## What

* Add a default value for `externalConfigurationServiceUrl` in `application.yml`

## Why

When attempting to run the adaptor locally, the adaptor fails to start as the configuration for `PEM111_ITK_EXTERNAL_CONFIGURATION_URL` is not set.  

This change populates a default value to allow for easier local development.

## Type of change

Please delete options that are not relevant.

- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation where required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](../CHANGELOG.md) with details of my change in the UNRELEASED section if this change affects end users.
